### PR TITLE
Also send Interval when publishing stats

### DIFF
--- a/homie/device.py
+++ b/homie/device.py
@@ -188,6 +188,7 @@ class HomieDevice:
         _time = time
         if _time() > self.next_update:
             uptime = _time() - self.start_time
+            self.publish(b"$stats/interval", self.stats_interval)
             self.publish(b"$stats/uptime", uptime)
             self.publish(b"$stats/freeheap", gc.mem_free())
             # set next update


### PR DESCRIPTION
All devices also announce "interval" as stats, but it is not sent regularly. 
openhab's 2.4 implementation of MQTT sets the device offline, if this stat is not published :(